### PR TITLE
#6 made publish job dependent

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v5


### PR DESCRIPTION
## Summary
Made NuGet Publish job depend on a succeeding CI job

Fixes #6 
