### PR TITLE
hotfix: Update workflow

### DIFF
--- a/.github/workflows/create-tag-on-merge.yml
+++ b/.github/workflows/create-tag-on-merge.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   create-tag:
@@ -18,6 +19,7 @@ jobs:
 
     steps:
       - name: Create tag if missing
+        id: tag
         uses: actions/github-script@v7
         with:
           script: |
@@ -44,6 +46,7 @@ jobs:
             try {
               await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
               core.info(`Tag '${tag}' already exists. Skipping.`);
+              core.setOutput("tag", tag);
               return;
             } catch (e) {
               // expected if it doesn't exist
@@ -57,3 +60,26 @@ jobs:
             });
 
             core.info(`Created tag '${tag}' at ${sha}.`);
+            core.setOutput("tag", tag);
+
+      - name: Dispatch publish workflow for the created tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const tag = "${{ steps.tag.outputs.tag }}";
+
+            if (!tag) {
+              core.setFailed("Tag output is missing; cannot dispatch publish workflow.");
+              return;
+            }
+
+            await github.rest.actions.createWorkflowDispatch({
+              owner,
+              repo,
+              workflow_id: "publish.yml",
+              ref: tag
+            });
+
+            core.info(`Dispatched publish.yml for ref '${tag}'.`);

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,10 @@
 name: Publish NuGet
 
 on:
+  workflow_dispatch:
   push:
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v*.*.*"
 
 permissions:
   contents: write

--- a/OpenSourceInitiative.LicenseApi.slnx
+++ b/OpenSourceInitiative.LicenseApi.slnx
@@ -5,6 +5,7 @@
         <File Path=".github/workflows/ci.yml" />
         <File Path=".github/workflows/publish.yml" />
         <File Path=".github/workflows/codeql.yml" />
+        <File Path=".github/workflows/create-tag-on-merge.yml"/>
         <File Path="CODE_OF_CONDUCT.md" />
         <File Path="Directory.Build.props" />
         <File Path="LICENSE" />


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve the release automation process. The main improvements are to the tagging and publishing workflows, ensuring that tags are created and the publish workflow is reliably triggered. Additionally, the new workflow file is added to the solution structure.

**Workflow automation improvements:**

* Added the `.github/workflows/create-tag-on-merge.yml` workflow to the solution and as a tracked file in the solution structure (`OpenSourceInitiative.LicenseApi.slnx`).
* Updated `create-tag-on-merge.yml` to grant `actions: write` permissions and set the output `tag` after tag creation or detection, making it usable in subsequent steps. [[1]](diffhunk://#diff-2f0f5e39d3cb4b923f3f3a1065d7ddf44b9e91abf06a78f478b3828a7dda66adR9) [[2]](diffhunk://#diff-2f0f5e39d3cb4b923f3f3a1065d7ddf44b9e91abf06a78f478b3828a7dda66adR49)
* Added a step to `create-tag-on-merge.yml` to dispatch the `publish.yml` workflow for the created tag, ensuring the publish process is triggered automatically after tagging.
* Modified `publish.yml` to support manual triggering via `workflow_dispatch` and to match a broader tag pattern (`v*.*.*`), making the workflow more flexible for various versioning schemes.
* Added an explicit step ID (`id: tag`) to the tag creation step in `create-tag-on-merge.yml` for reliable output referencing.
